### PR TITLE
Use queues for color instead of only the most recent value

### DIFF
--- a/FrameAnalysis.cs
+++ b/FrameAnalysis.cs
@@ -100,15 +100,15 @@ namespace zecil.AmbiHueTv
 
             using (var stream = bitmap.PixelBuffer.AsStream())
             {
-                int red = 0;
+                int blue = 0;
 
-                while (red != -1)
+                while (blue != -1)
                 {
-                    red = stream.ReadByte();
-                    if (red > -1)
+                    blue = stream.ReadByte();
+                    if (blue > -1)
                     {
                         var green = stream.ReadByte();
-                        var blue = stream.ReadByte();
+                        var red = stream.ReadByte();
                         var alpha = stream.ReadByte();
 
                         if (IsInCalibrationFrame(x, y, calTop, calLeft, calBottom, calRight))
@@ -158,15 +158,15 @@ namespace zecil.AmbiHueTv
 
             using (var stream = bitmap.PixelBuffer.AsStream())
             {
-                int red = 0;
+                int blue = 0;
 
-                while (red != -1)
+                while (blue != -1)
                 {
-                    red = stream.ReadByte();
-                    if (red > -1)
+                    blue = stream.ReadByte();
+                    if (blue > -1)
                     {
                         var green = stream.ReadByte();
-                        var blue = stream.ReadByte();
+                        var red = stream.ReadByte();
                         var alpha = stream.ReadByte();
 
                         if (IsInCalibrationFrame(x, y, calTop, calLeft, calBottom, calRight))
@@ -212,15 +212,15 @@ namespace zecil.AmbiHueTv
 
             using (var stream = bitmap.PixelBuffer.AsStream())
             {
-                int red = 0;
+                int blue = 0;
 
-                while (red != -1)
+                while (blue != -1)
                 {
-                    red = stream.ReadByte();
-                    if (red > -1)
+                    blue = stream.ReadByte();
+                    if (blue > -1)
                     {
                         var green = stream.ReadByte();
-                        var blue = stream.ReadByte();
+                        var red = stream.ReadByte();
                         var alpha = stream.ReadByte();
 
                         if (IsInCalibrationFrame(x, y, calTop, calLeft, calBottom, calRight))

--- a/Hue.cs
+++ b/Hue.cs
@@ -1,28 +1,124 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Threading;
 using Q42.HueApi;
 using Q42.HueApi.Interfaces;
 
 namespace zecil.AmbiHueTv
 {
+    public class HueColor
+    {
+        public int red = 0;
+        public int green = 0;
+        public int blue = 0;
+    }
+
     public class Hue
     {
-
         public static string AppName = "AmbiHueTv";
         public static string DeviceName = "pi";
+
+        #region Configurable settings
+        /// <summary>
+        /// Specifies the number of times to record color information per second.
+        /// </summary>
+        private const int RECORDSPERSECOND = 5;
+        /// <summary>
+        /// Number of seconds that color data is considered short-term
+        /// </summary>
+        private const int SHORTSECONDS = 6;
+        /// <summary>
+        /// Multiplier to determine how long color data is kept in long-term storage.
+        /// SHORTSECONDS is multiplied by this value to determine the length of time.
+        /// </summary>
+        private const int LONGMULTIPLIER = 10;
+        /// <summary>
+        /// Weighting factor applied to short-term data when the short and long term values are averaged to determine the target color.
+        /// </summary>
+        private const double SHORTWEIGHT = 1;
+        /// <summary>
+        /// Weighting factor applied to long-term data when the short and long term values are averaged to determine the target color.
+        /// </summary>
+        private const double LONGWEIGHT = 1;
+        /// <summary>
+        /// Maximum change allowed in each color change per update interval.
+        /// Small numbers create smoother transitions, but lights take longer to reach the target color.
+        /// Large numbers cause lights to reach target faster, but transitions will be more obvious.
+        /// </summary>
+        private const int CHANGELIMIT = 3;
+        /// <summary>
+        /// Number of times to update the light color each second.
+        /// </summary>
+        private const int LIGHTUPDATESPERSECOND = 2;
+        #endregion
+
+        #region Non-configurable settings
+        // These constants are simple calculations based on the configurable constants.
+        // These should not generally be changed.
+        private const int QUEUELENGTH = SHORTSECONDS * RECORDSPERSECOND;
+        private const int RECORDINTERVAL = 1000 / RECORDSPERSECOND;
+        private const int CHANGEINTERVAL = 1000 / LIGHTUPDATESPERSECOND; 
+        #endregion
 
         private ObservableCollection<string> _bridgeIps;
         private IEnumerable<Light> _allLights;
         private ObservableCollection<Light> _filteredLights;
         private ILocalHueClient _client;
 
+        #region Color Queues
+        // These Queues contain the short-term color information
+        private Queue<int> redQueue = new Queue<int>(QUEUELENGTH + 1);
+        private Queue<int> blueQueue = new Queue<int>(QUEUELENGTH + 1);
+        private Queue<int> greenQueue = new Queue<int>(QUEUELENGTH + 1);
+
+        // These Queues contain the long-term color information
+        private Queue<int> redLongQueue = new Queue<int>((QUEUELENGTH * LONGMULTIPLIER) + 1);
+        private Queue<int> blueLongQueue = new Queue<int>((QUEUELENGTH * LONGMULTIPLIER) + 1);
+        private Queue<int> greenLongQueue = new Queue<int>((QUEUELENGTH * LONGMULTIPLIER) + 1);
+        #endregion
+
+        #region Color Objects
+        /// <summary>
+        /// The target color based on the recorded color data.
+        /// </summary>
+        private HueColor target = new HueColor();
+        /// <summary>
+        /// The current color being sent to the hue lights
+        /// </summary>
+        private HueColor current = new HueColor();
+        /// <summary>
+        /// The most recent color provided by the frame analysis
+        /// </summary>
+        private HueColor recent = new HueColor();
+
+        /// <summary>
+        /// Locking object used when target colors or queues are updated
+        /// </summary>
+        private object targetUpdate = new object(); 
+        #endregion
+
+        #region Timer objects
+        private Timer changeTimer;
+        private Timer recordTimer;
+        AutoResetEvent autoChangeEvent = new AutoResetEvent(false);
+        AutoResetEvent autoRecordEvent = new AutoResetEvent(false);
+        private bool changeTimerStarted = false;
+        private bool recordTimerStarted = false; 
+        #endregion
+
+        public Hue()
+        {
+            // Initialize the timers used for the light change and color record tasks     
+            changeTimer = new Timer(ChangeColorTask,autoChangeEvent,Timeout.Infinite,500);
+            recordTimer = new Timer(RecordColorTask, autoRecordEvent, Timeout.Infinite, 200);
+        }
 
         public async Task<string> FindFirstBridge()
         {
-
             _bridgeIps = new ObservableCollection<string>();
             IBridgeLocator locator = new HttpBridgeLocator();
             IEnumerable<string> bridgeIPs = await locator.LocateBridgesAsync(TimeSpan.FromSeconds(5));
@@ -39,7 +135,6 @@ namespace zecil.AmbiHueTv
             }
 
             return string.Empty;
-
         }
 
         public async Task RegisterIfNeeded()
@@ -83,7 +178,6 @@ namespace zecil.AmbiHueTv
 
         }
 
-
         public async Task TurnOffFilteredLights()
         {
             var modifiedLights = new List<string>(_filteredLights.Select(a => a.Id));
@@ -94,52 +188,160 @@ namespace zecil.AmbiHueTv
 
         }
 
-        public async Task<bool> ChangeFilteredLightsColor(byte red, byte green, byte blue)
+        /// <summary>
+        /// Sets the most recent color data used by the color selection algorithm
+        /// </summary>
+        /// <param name="red">Red value, expressed as an integer from 0-254</param>
+        /// <param name="green">Green value, expressed as an integer from 0-254</param>
+        /// <param name="blue">Blue value, expressed as an integer from 0-254</param>
+        public void UpdateColor(int red, int green, int blue)
         {
-            if (IsSignificantChange(red, green, blue))
+            /* 
+             *  Assign the submitted data to the recent object.
+             *  It will added to the color queues by the record timer.
+             *  Using the timer allows data to be added to the queue at a 
+             *  constant interval.
+             */
+            recent.red = red;
+            recent.green = green;
+            recent.blue = blue;
+
+            // Start the record timer if it hasn't already been started.
+            // This should only happen the first time that UpdateColor is called.
+            if (!recordTimerStarted)
             {
-                var modifiedLights = new List<string>(_filteredLights.Select(a => a.Id));
-                var command = new LightCommand
+                recordTimer.Change(0, RECORDINTERVAL);
+                recordTimerStarted = true;
+            }
+#if DEBUG
+            Debug.WriteLine("Red " + redQueue.Count.ToString() + " Green " + greenQueue.Count.ToString() + " Blue " + blueQueue.Count.ToString());
+            Debug.WriteLine("Red " + current.red + "/" + target.red + "Blue " + current.blue + "/" + target.blue + "Green " + current.green + "/" + target.green);
+#endif
+
+        }
+
+        /// <summary>
+        /// Determines the most acceptable value for each light update
+        /// </summary>
+        /// <param name="currentValue"></param>
+        /// <param name="targetValue"></param>
+        /// <returns>The closest value to the target that can be set limited by CHANGELIMIT</returns>
+        private static int adjustColor(int currentValue, int targetValue)
+        {
+            if (currentValue != targetValue)
+            {
+                if (currentValue > targetValue) currentValue -= Math.Min((currentValue - targetValue), CHANGELIMIT);
+                if (targetValue > currentValue) currentValue += Math.Min((targetValue - currentValue), CHANGELIMIT);
+            }
+            return currentValue;
+        }
+
+        /// <summary>
+        /// Get the weighted average of the provided queues based on the constant configuration settings.
+        /// </summary>
+        /// <param name="shortQueue">The short-term queue to use for the calculation</param>
+        /// <param name="longQueue">The long-term queue to use for the calculation</param>
+        /// <returns></returns>
+        private static int getWeightedAverage(Queue<int> shortQueue, Queue<int> longQueue)
+        {
+            int weightedAverage;
+
+            // Determine if there is data in the long queue.
+            // If there is not, only use the unweighted short queue for the calculation.
+            if(longQueue.Count > 0)
+            {
+                // Average the long and short queues with the appropriate weighting settings.
+                weightedAverage = (int)(((shortQueue.Average() * SHORTWEIGHT) + (longQueue.Average() * LONGWEIGHT)) / (SHORTWEIGHT + LONGWEIGHT));
+            } else
+            {
+                // There was no long-term data, Provide the average of the short queue
+                weightedAverage = (int)(shortQueue.Average());
+            }
+            return weightedAverage;
+        }
+
+        /// <summary>
+        /// Function called by the change timer that sets the current light color
+        /// </summary>
+        /// <param name="stateInfo"></param>
+        private void ChangeColorTask(Object stateInfo)
+        {
+            // This lock prevents the queues from being updated until the target color is determined.
+            lock (targetUpdate)
+            {
+                // Update the target color object with the weighted average for each color channel
+                target.blue = getWeightedAverage(blueQueue, blueLongQueue);
+                target.green = getWeightedAverage(greenQueue, greenLongQueue);
+                target.red = getWeightedAverage(redQueue, redLongQueue);
+            }
+
+            // Determine the new color to send to the lights based on the target color and change limits
+            current.blue = adjustColor(current.blue, target.blue);
+            current.red = adjustColor(current.red, target.red);
+            current.green = adjustColor(current.green, target.green);
+
+            // Send the new color to the lights
+            var modifiedLights = new List<string>(_filteredLights.Select(a => a.Id));
+            var command = new LightCommand
+            {
+                TransitionTime = TimeSpan.FromMilliseconds(CHANGEINTERVAL)
+            };
+            command.SetColor(current.red, current.green, current.blue);
+            SetColors(command, modifiedLights);
+        }
+
+        private void SetColors(LightCommand command,List<string> modifiedLights)
+        {
+            Task working = _client.SendCommandAsync(command, modifiedLights);
+            working.Wait();
+        }
+
+        /// <summary>
+        /// Shift old data from the short queue to the long queue and very old data out of the long queue
+        /// </summary>
+        /// <param name="shortQueue"></param>
+        /// <param name="longQueue"></param>
+        private static void shiftQueue(ref Queue<int> shortQueue, ref Queue<int> longQueue)
+        {
+            if (shortQueue.Count == QUEUELENGTH)
+            {
+                if (longQueue.Count == QUEUELENGTH*LONGMULTIPLIER)
                 {
-                    TransitionTime = TimeSpan.FromMilliseconds(50)
-                };
-                command.SetColor(red, green, blue);
-                await _client.SendCommandAsync(command, modifiedLights);
-                return true;
-            }
-            else
-            {
-                return false;
+                    longQueue.Dequeue();
+                }
+
+                longQueue.Enqueue(shortQueue.Dequeue());
             }
         }
 
-        private byte _lastRed;
-        private byte _lastGreen;
-        private byte _lastBlue;
-
-        public bool IsSignificantChange(byte red, byte green, byte blue)
+        /// <summary>
+        /// Function called by the record timer. Updates the color queues with the most recent color data.
+        /// </summary>
+        /// <param name="stateInfo"></param>
+        private void RecordColorTask(Object stateInfo)
         {
-            const int deltaThreshold = 30;
+            // Lock the queues so that the average won't be taken while the queue is being updated
+            lock (targetUpdate)
+            {
+                // Shift data from the short-term queues to the long-term queues
+                shiftQueue(ref redQueue, ref redLongQueue);
+                shiftQueue(ref blueQueue, ref blueLongQueue);
+                shiftQueue(ref greenQueue, ref greenLongQueue);
 
-            if (_lastBlue == 0 && _lastGreen == 0 && _lastBlue == 0)
-            {
-                _lastRed = red;
-                _lastGreen = green;
-                _lastBlue = blue;
-                return true;
+                // Add the most recent data to the short-term queues
+                redQueue.Enqueue(recent.red);
+                greenQueue.Enqueue(recent.green);
+                blueQueue.Enqueue(recent.blue);
             }
-
-            if (Math.Abs((red - _lastRed) + (green - _lastGreen) + (blue - _lastBlue)) > deltaThreshold)
+            
+            // Start the change timer if it hasn't already been started.
+            // This should only happen the first time the function is called
+            if (!changeTimerStarted)
             {
-                _lastRed = red;
-                _lastGreen = green;
-                _lastBlue = blue;
-                return true;
-            }
-            else
-            {
-                return false; 
+                changeTimer.Change(0, CHANGEINTERVAL);
+                changeTimerStarted = true;
             }
         }
+
     }
 }

--- a/MainPage.xaml.cs
+++ b/MainPage.xaml.cs
@@ -31,7 +31,6 @@ namespace zecil.AmbiHueTv
         private MediaCapture _mediaCapture;
         private bool _isSyncing;
         private CalibrationState _calState = CalibrationState.NotCalibrating;
-
         public INotifyTaskCompletion Initialization { get; private set; }
 
         #region UI Helper Functions
@@ -97,7 +96,6 @@ namespace zecil.AmbiHueTv
 
             SetStartupButtonVisibility();
 
-
             algorithm.SelectedIndex = (int)Settings.TheAnalysisAlgorithm;
             Bias.SelectedIndex = (int)Settings.TheBiasAlgorithm;
 
@@ -160,7 +158,7 @@ namespace zecil.AmbiHueTv
             {
                 var point = e.GetPosition(previewElement);
                 Settings.CalibrationLeft = point.X;
-                Settings.CalibreationTop = point.Y;
+                Settings.CalibrationTop = point.Y;
                 _calState = CalibrationState.CalibrationSecondPoint;
                 fps.Text = "Click Lower Right Corner of Calibration Box on Preview";
                 return;
@@ -170,7 +168,7 @@ namespace zecil.AmbiHueTv
             {
                 var point = e.GetPosition(previewElement);
                 Settings.CalibrationWidth = point.X - Settings.CalibrationLeft;
-                Settings.CalibrationHeight = point.Y - Settings.CalibreationTop;
+                Settings.CalibrationHeight = point.Y - Settings.CalibrationTop;
                 _calState = CalibrationState.NotCalibrating;
                 ShowCalibrationBox();
                 UpdateStatus("Calibration Completed");
@@ -228,7 +226,7 @@ namespace zecil.AmbiHueTv
 
         private void ShowCalibrationBox()
         {
-            calibration.Margin = new Thickness(Settings.CalibrationLeft, Settings.CalibreationTop, 0, 0);
+            calibration.Margin = new Thickness(Settings.CalibrationLeft, Settings.CalibrationTop, 0, 0);
             calibration.Width = Settings.CalibrationWidth;
             calibration.Height = Settings.CalibrationHeight;
         }
@@ -246,12 +244,13 @@ namespace zecil.AmbiHueTv
                 try
                 {
                     await _mediaCapture.GetPreviewFrameAsync(currentFrame);
+
                     analysis.AnalyzeFrame(ref currentFrame, 
                                           Settings.TheAnalysisAlgorithm, 
                                           Settings.TheBiasAlgorithm, 
-                                          (int)Settings.CalibreationTop, 
+                                          (int)Settings.CalibrationTop, 
                                           (int)Settings.CalibrationLeft, 
-                                          (int)(Settings.CalibreationTop + Settings.CalibrationHeight), 
+                                          (int)(Settings.CalibrationTop + Settings.CalibrationHeight), 
                                           (int)(Settings.CalibrationLeft + Settings.CalibrationWidth));
                     count++;
 #if DEBUG

--- a/Settings.cs
+++ b/Settings.cs
@@ -24,8 +24,8 @@ namespace zecil.AmbiHueTv
         private const string CalibrationLeftKey = "left_key";
         private static readonly double CalibrationLeftDefault = 0;
 
-        private const string CalibreationTopKey = "top_key";
-        private static readonly double CalibreationTopDefault = 0;
+        private const string CalibrationTopKey = "top_key";
+        private static readonly double CalibrationTopDefault = 0;
 
         private const string CalibrationWidthKey = "width_key";
         private static readonly double CalibrationWidthDefault = 320;
@@ -67,10 +67,10 @@ namespace zecil.AmbiHueTv
             set { AppSettings.AddOrUpdateValue(CalibrationLeftKey, value); }
         }
 
-        public static double CalibreationTop
+        public static double CalibrationTop
         {
-            get { return AppSettings.GetValueOrDefault(CalibreationTopKey, CalibreationTopDefault); }
-            set { AppSettings.AddOrUpdateValue(CalibreationTopKey, value); }
+            get { return AppSettings.GetValueOrDefault(CalibrationTopKey, CalibrationTopDefault); }
+            set { AppSettings.AddOrUpdateValue(CalibrationTopKey, value); }
         }
 
         public static double CalibrationWidth


### PR DESCRIPTION
This request includes three modifications:
 - Fix byte order in FrameAnalysis, it currently retrieves the bytes in the wrong order (as RGBA instead of BGRA)
 - Fix a typo in the calibration settings
 - Adds short- and long-term queues to the Hue class with a variety of settings to make the color selection / transition process smoother. Color changes on the base implementation tended to be very abrupt and distracting for me; the queues allow current and historical data to be considered together (avoiding having a change made for a short change in the image) and limit the change per second so that the transition occurs gradually instead of immediately. This creates what is (to me) a more aesthetically pleasing lighting effect.